### PR TITLE
feat: dynamic dock — DockItem, DockRepository, DockAdapter

### DIFF
--- a/app/src/main/java/com/achunt/weboslauncher/DockAdapter.kt
+++ b/app/src/main/java/com/achunt/weboslauncher/DockAdapter.kt
@@ -1,0 +1,92 @@
+package com.achunt.weboslauncher
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.drawable.Drawable
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.core.content.res.ResourcesCompat
+import androidx.recyclerview.widget.RecyclerView
+
+/**
+ * Drives the horizontal dock RecyclerView.
+ *
+ * Each item is a 56dp × 56dp icon. The last item is always the drawer-launcher
+ * button (identified by [DockItem.isDrawerButton]).
+ *
+ * Interactions:
+ *  - Tap → launch app  (or open drawer for drawer button)
+ *  - Long-press → remove from dock  (no-op for drawer button)
+ *
+ * The adapter does NOT write to [DockRepository] itself — it delegates all
+ * mutations back to the host fragment via [DockInteractionListener] so the
+ * fragment can reload the full list and call [notifyDataSetChanged] cleanly.
+ */
+class DockAdapter(
+    private val context: Context,
+    private var items: MutableList<DockItem>,
+    private val listener: DockInteractionListener
+) : RecyclerView.Adapter<DockAdapter.DockViewHolder>() {
+
+    interface DockInteractionListener {
+        fun onDockAppClicked(item: DockItem)
+        fun onDockDrawerClicked()
+        fun onDockItemLongPressed(item: DockItem)
+    }
+
+    private val pm: PackageManager = context.packageManager
+
+    inner class DockViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val icon: ImageView = view.findViewById(R.id.dock_item_icon)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DockViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_dock, parent, false)
+        return DockViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: DockViewHolder, position: Int) {
+        val item = items[position]
+
+        if (item.isDrawerButton) {
+            // Drawer launcher — always uses the static applauncher drawable
+            val drawable = ResourcesCompat.getDrawable(
+                context.resources, R.drawable.applauncher, context.theme
+            )
+            holder.icon.setImageDrawable(drawable)
+            holder.icon.background = ResourcesCompat.getDrawable(
+                context.resources, R.drawable.dockshadow, context.theme
+            )
+            holder.itemView.setOnClickListener { listener.onDockDrawerClicked() }
+            holder.itemView.setOnLongClickListener(null)
+        } else {
+            holder.icon.setImageDrawable(loadIcon(item.packageName))
+            holder.icon.background = ResourcesCompat.getDrawable(
+                context.resources, R.drawable.dockshadow, context.theme
+            )
+            holder.itemView.setOnClickListener { listener.onDockAppClicked(item) }
+            holder.itemView.setOnLongClickListener {
+                listener.onDockItemLongPressed(item)
+                true
+            }
+        }
+    }
+
+    fun updateItems(newItems: List<DockItem>) {
+        items = newItems.toMutableList()
+        notifyDataSetChanged()
+    }
+
+    private fun loadIcon(packageName: String): Drawable? {
+        return try {
+            pm.getApplicationIcon(packageName)
+        } catch (e: PackageManager.NameNotFoundException) {
+            ResourcesCompat.getDrawable(context.resources, R.drawable.applauncher, context.theme)
+        }
+    }
+}

--- a/app/src/main/java/com/achunt/weboslauncher/DockItem.kt
+++ b/app/src/main/java/com/achunt/weboslauncher/DockItem.kt
@@ -1,0 +1,13 @@
+package com.achunt.weboslauncher
+
+/**
+ * Lightweight model for a single dock slot.
+ *
+ * [packageName] is the only field persisted. Label and icon are resolved at
+ * runtime from the PackageManager so we never store stale drawable data.
+ */
+data class DockItem(
+    val packageName: String,
+    val label: String,
+    val isDrawerButton: Boolean = false
+)

--- a/app/src/main/java/com/achunt/weboslauncher/DockRepository.kt
+++ b/app/src/main/java/com/achunt/weboslauncher/DockRepository.kt
@@ -1,0 +1,163 @@
+package com.achunt.weboslauncher
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONException
+
+/**
+ * Single source of truth for the dock item list.
+ *
+ * Persists an ordered JSON array of package-name strings in SharedPreferences
+ * under the key [PREFS_NAME]/[KEY_DOCK]. The special drawer-button entry is
+ * represented by the sentinel [DRAWER_SENTINEL] and is always appended last
+ * (never stored — it is injected at read time).
+ *
+ * Default seed: phone → contacts → messages → browser, resolved via the
+ * same SpecialApps prefs that HomeScreenK already uses, so existing users
+ * keep their current dock on first launch.
+ */
+class DockRepository(private val context: Context) {
+
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val pm: PackageManager = context.packageManager
+
+    companion object {
+        const val PREFS_NAME = "DockPrefs"
+        const val KEY_DOCK = "dock_items"
+        const val DRAWER_SENTINEL = "__drawer__"
+        const val MAX_DOCK_ITEMS = 6   // excludes drawer button
+        private const val TAG = "DockRepository"
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /** Returns the current dock list, with the drawer button appended. */
+    fun getDockItems(): List<DockItem> {
+        val packages = loadPackages()
+        val items = packages.mapNotNull { pkg -> resolveDockItem(pkg) }.toMutableList()
+        // Always append the drawer launcher button last
+        items.add(DockItem(DRAWER_SENTINEL, "", isDrawerButton = true))
+        return items
+    }
+
+    /** Adds [packageName] to the dock. No-op if already present or dock is full. */
+    fun addItem(packageName: String): Boolean {
+        val current = loadPackages()
+        if (current.contains(packageName)) return false
+        if (current.size >= MAX_DOCK_ITEMS) return false
+        savePackages(current + packageName)
+        return true
+    }
+
+    /** Removes [packageName] from the dock. */
+    fun removeItem(packageName: String) {
+        savePackages(loadPackages().filter { it != packageName })
+    }
+
+    /** Moves item at [fromIndex] to [toIndex] (both exclude the drawer button). */
+    fun moveItem(fromIndex: Int, toIndex: Int) {
+        val list = loadPackages().toMutableList()
+        if (fromIndex !in list.indices || toIndex !in list.indices) return
+        val item = list.removeAt(fromIndex)
+        list.add(toIndex, item)
+        savePackages(list)
+    }
+
+    /** True if the dock contains no persisted items yet (first launch). */
+    fun isEmpty(): Boolean = !prefs.contains(KEY_DOCK)
+
+    /**
+     * Seeds the dock from the legacy SpecialApps SharedPreferences so that
+     * existing users don't lose their configured phone/contacts/messages/browser.
+     * Falls back to intent-resolution for any slot that has no saved package.
+     */
+    fun seedFromLegacy() {
+        val special = context.getSharedPreferences("SpecialApps", Context.MODE_PRIVATE)
+        val candidates = listOfNotNull(
+            special.getString("PhonePackageName", null)
+                ?: resolveDefaultPhone(),
+            special.getString("ContactsPackageName", null)
+                ?: resolveDefaultContacts(),
+            special.getString("MessagesPackageName", null)
+                ?: resolveDefaultMessages(),
+            special.getString("BrowserPackageName", null)
+                ?: resolveDefaultBrowser()
+        ).distinct().filter { isInstalled(it) }
+
+        savePackages(candidates)
+        Log.d(TAG, "Seeded dock from legacy: $candidates")
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    private fun loadPackages(): List<String> {
+        val json = prefs.getString(KEY_DOCK, null) ?: return emptyList()
+        return try {
+            val arr = JSONArray(json)
+            (0 until arr.length()).map { arr.getString(it) }
+        } catch (e: JSONException) {
+            Log.e(TAG, "Failed to parse dock JSON", e)
+            emptyList()
+        }
+    }
+
+    private fun savePackages(list: List<String>) {
+        val arr = JSONArray()
+        list.forEach { arr.put(it) }
+        prefs.edit().putString(KEY_DOCK, arr.toString()).apply()
+    }
+
+    private fun resolveDockItem(packageName: String): DockItem? {
+        return try {
+            val info = pm.getApplicationInfo(packageName, 0)
+            DockItem(
+                packageName = packageName,
+                label = pm.getApplicationLabel(info).toString()
+            )
+        } catch (e: PackageManager.NameNotFoundException) {
+            Log.w(TAG, "Dock package not found, removing: $packageName")
+            removeItem(packageName)   // auto-clean uninstalled apps
+            null
+        }
+    }
+
+    private fun isInstalled(pkg: String): Boolean = try {
+        pm.getApplicationInfo(pkg, 0)
+        true
+    } catch (e: PackageManager.NameNotFoundException) { false }
+
+    private fun resolveDefaultPhone(): String? {
+        val intent = android.content.Intent(android.content.Intent.ACTION_DIAL)
+        return pm.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
+            ?.activityInfo?.packageName
+    }
+
+    private fun resolveDefaultContacts(): String? {
+        val intent = android.content.Intent(android.content.Intent.ACTION_VIEW)
+        intent.data = android.net.Uri.parse("content://contacts")
+        return pm.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
+            ?.activityInfo?.packageName
+    }
+
+    private fun resolveDefaultMessages(): String? {
+        val intent = android.content.Intent(android.content.Intent.ACTION_SENDTO,
+            android.net.Uri.parse("smsto:"))
+        return pm.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
+            ?.activityInfo?.packageName
+    }
+
+    private fun resolveDefaultBrowser(): String? {
+        val intent = android.content.Intent(android.content.Intent.ACTION_VIEW,
+            android.net.Uri.parse("http://"))
+        return pm.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
+            ?.activityInfo?.packageName
+    }
+}

--- a/app/src/main/java/com/achunt/weboslauncher/HomeScreenK.kt
+++ b/app/src/main/java/com/achunt/weboslauncher/HomeScreenK.kt
@@ -1,6 +1,7 @@
 package com.achunt.weboslauncher
 
 import android.app.ActivityManager
+import android.app.AlertDialog
 import android.app.usage.UsageStats
 import android.app.usage.UsageStatsManager
 import android.appwidget.AppWidgetHost
@@ -14,6 +15,7 @@ import android.content.pm.ResolveInfo
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.provider.ContactsContract
 import android.transition.Slide
 import android.util.Log
@@ -21,8 +23,6 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.GridLayout
-import android.widget.ImageView
 import android.widget.LinearLayout
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
@@ -33,19 +33,20 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 
-class HomeScreenK : Fragment(), FragmentManager.OnBackStackChangedListener {
-    lateinit var imageViewDrawer: ImageView
-    lateinit var imageViewPhone: ImageView
-    lateinit var imageViewContacts: ImageView
-    lateinit var imageViewMessages: ImageView
-    lateinit var imageViewBrowser: ImageView
-    lateinit var gridDock: GridLayout
+class HomeScreenK : Fragment(),
+    FragmentManager.OnBackStackChangedListener,
+    DockAdapter.DockInteractionListener {
+
+    // Dock
+    private lateinit var dockRecycler: RecyclerView
+    private lateinit var dockAdapter: DockAdapter
+    private lateinit var dockRepository: DockRepository
+
     lateinit var widgets: LinearLayout
     lateinit var recents: RecyclerView
     lateinit var sharedPrefH: SharedPreferences
@@ -55,9 +56,9 @@ class HomeScreenK : Fragment(), FragmentManager.OnBackStackChangedListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val start = System.currentTimeMillis()
-        GlobalScope.launch(Dispatchers.IO) {
+        lifecycleScope.launch(Dispatchers.IO) {
             val adapter = RAdapter(requireContext())
-            launch(Dispatchers.Main) {
+            withContext(Dispatchers.Main) {
                 apps = adapter.appsList
                 appsToPass = adapter.resolveList
                 adapterSystem = RAdapterSystem(requireContext(), appsToPass)
@@ -80,198 +81,45 @@ class HomeScreenK : Fragment(), FragmentManager.OnBackStackChangedListener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        imageViewDrawer = view.findViewById(R.id.icon_drawer)
-        imageViewPhone = view.findViewById(R.id.phone)
-        imageViewContacts = view.findViewById(R.id.cnt)
-        imageViewMessages = view.findViewById(R.id.msg)
-        imageViewBrowser = view.findViewById(R.id.brs)
-        gridDock = view.findViewById(R.id.dock)
+
         widgets = view.findViewById(R.id.widgets)
         recents = view.findViewById(R.id.recents)
+        dockRecycler = view.findViewById(R.id.dock)
         sharedPrefH = requireContext().getSharedPreferences("Settings", Context.MODE_PRIVATE)
         val theme = sharedPrefH.getString("themeName", "Classic")
         val recentsT = sharedPrefH.getBoolean("recents", false)
         parentFragmentManager.addOnBackStackChangedListener(this)
 
+        // ---- Dock setup ----
+        dockRepository = DockRepository(requireContext())
+        if (dockRepository.isEmpty()) {
+            dockRepository.seedFromLegacy()
+        }
+        val dockLayoutManager = LinearLayoutManager(
+            requireContext(), LinearLayoutManager.HORIZONTAL, false
+        ).apply { stackFromEnd = false }
+        dockRecycler.layoutManager = dockLayoutManager
+        dockRecycler.itemAnimator = DefaultItemAnimator()
+        dockAdapter = DockAdapter(
+            requireContext(),
+            dockRepository.getDockItems().toMutableList(),
+            this
+        )
+        dockRecycler.adapter = dockAdapter
+        applyDockTheme(theme)
+
+        // ---- Entry animations ----
         view.post {
             val animationDuration = 500L
-            animateImageViewTranslation(imageViewDrawer, animationDuration, false)
-            animateImageViewTranslation(imageViewPhone, animationDuration, false)
-            animateImageViewTranslation(imageViewContacts, animationDuration, false)
-            animateImageViewTranslation(imageViewMessages, animationDuration, false)
-            animateImageViewTranslation(imageViewBrowser, animationDuration, false)
+            animateDock(animationDuration, false)
             if (recentsT) {
-                launchWithDelay(500) {
-                    recentsList(requireContext())
-                }
+                launchWithDelay(500) { recentsList(requireContext()) }
             }
         }
+
         val w = requireActivity().window
         w.statusBarColor = ContextCompat.getColor(requireActivity(), R.color.empty)
         widgets.animate().alpha(1f).setDuration(1000).start()
-
-
-        when (theme) {
-            "Classic" -> {
-                imageViewPhone.setImageResource(R.drawable.phone)
-                imageViewContacts.setImageResource(R.drawable.cnt)
-                imageViewMessages.setImageResource(R.drawable.msg)
-                imageViewBrowser.setImageResource(R.drawable.brs)
-            }
-
-            "Classic3" -> {
-                imageViewPhone.setImageResource(R.drawable.phone)
-                imageViewContacts.setImageResource(R.drawable.cnt)
-                imageViewMessages.setImageResource(R.drawable.msg)
-                imageViewBrowser.setImageResource(R.drawable.brs)
-            }
-            "Mochi" -> {
-                imageViewPhone.setImageResource(R.drawable.mochiphone)
-                imageViewContacts.setImageResource(R.drawable.mochicontacts)
-                imageViewMessages.setImageResource(R.drawable.mochimessages)
-                imageViewBrowser.setImageResource(R.drawable.mochibrowser)
-                gridDock.background =
-                    context?.let { AppCompatResources.getDrawable(it, R.color.mochilight) }
-            }
-            "Modern" -> {
-                imageViewPhone.setImageResource(R.drawable.modernphone)
-                imageViewContacts.setImageResource(R.drawable.moderncontact)
-                imageViewMessages.setImageResource(R.drawable.modernmessages)
-                imageViewBrowser.setImageResource(R.drawable.modernbrowser)
-                gridDock.background =
-                    context?.let { AppCompatResources.getDrawable(it, R.drawable.modern_dock) }
-            }
-            "System" -> {
-                val browserIntent = Intent("android.intent.action.VIEW", Uri.parse("http://"))
-                val resolveBrowserInfo = view.context.packageManager.resolveActivity(
-                    browserIntent,
-                    PackageManager.MATCH_DEFAULT_ONLY
-                )
-                val phoneNumber = "1234567890" // Replace with the desired phone number
-                val dialIntent = Intent(Intent.ACTION_DIAL).apply {
-                    data = Uri.parse("tel:$phoneNumber")
-                }
-                val resolvePhoneInfo = view.context.packageManager.resolveActivity(
-                    dialIntent,
-                    PackageManager.MATCH_DEFAULT_ONLY
-                )
-                val contactsIntent = Intent(Intent.ACTION_VIEW)
-                contactsIntent.data = ContactsContract.Contacts.CONTENT_URI
-                val resolveContactsInfo = view.context.packageManager.resolveActivity(
-                    contactsIntent,
-                    PackageManager.MATCH_DEFAULT_ONLY
-                )
-                val smsUri = Uri.parse("smsto:$phoneNumber")
-                val smsIntent = Intent(Intent.ACTION_SENDTO, smsUri)
-                val resolveSmsInfo = view.context.packageManager.resolveActivity(
-                    smsIntent,
-                    PackageManager.MATCH_DEFAULT_ONLY
-                )
-                if (resolvePhoneInfo != null) {
-                    imageViewPhone.setImageDrawable(
-                        resolvePhoneInfo.activityInfo.applicationInfo.loadIcon(
-                            requireContext().packageManager
-                        )
-                    )
-                } else {
-                    // Phone app not found
-                    imageViewPhone.setImageResource(R.drawable.phone)
-                }
-                if (resolveContactsInfo != null) {
-                    imageViewContacts.setImageDrawable(
-                        resolveContactsInfo.activityInfo.applicationInfo.loadIcon(
-                            requireContext().packageManager
-                        )
-                    )
-                } else {
-                    // Contacts app not found
-                    imageViewContacts.setImageResource(R.drawable.cnt)
-                }
-                if (resolveSmsInfo != null) {
-                    imageViewMessages.setImageDrawable(
-                        resolveSmsInfo.activityInfo.applicationInfo.loadIcon(
-                            requireContext().packageManager
-                        )
-                    )
-                } else {
-                    // Messaging app not found
-                    imageViewMessages.setImageResource(R.drawable.msg)
-                }
-                if (resolveBrowserInfo != null) {
-                    imageViewBrowser.setImageDrawable(
-                        resolveBrowserInfo.activityInfo.applicationInfo.loadIcon(
-                            requireContext().packageManager
-                        )
-                    )
-                } else {
-                    // Browser app not found
-                    imageViewBrowser.setImageResource(R.drawable.brs)
-                }
-                gridDock.background =
-                    context?.let { AppCompatResources.getDrawable(it, R.color.abt) }
-            }
-        }
-
-        val sharedPrefs: SharedPreferences =
-            view.context.getSharedPreferences("SpecialApps", Context.MODE_PRIVATE)
-        imageViewDrawer.setOnClickListener {
-            widgets.animate().alpha(0f).setDuration(1000).start()
-            view.post {
-                val animationDuration = 500L
-                animateImageViewTranslation(imageViewDrawer, animationDuration, true)
-                animateImageViewTranslation(imageViewPhone, animationDuration, true)
-                animateImageViewTranslation(imageViewContacts, animationDuration, true)
-                animateImageViewTranslation(imageViewMessages, animationDuration, true)
-                animateImageViewTranslation(imageViewBrowser, animationDuration, true)
-            }
-            loadFragment(AppsDrawer())
-        }
-        imageViewPhone.setOnClickListener { v: View ->
-            val context = v.context
-            val phonePackageName = sharedPrefs.getString("PhonePackageName", null)
-            if (phonePackageName != null) {
-                goodbyeList.remove(phonePackageName) // Remove the package name from the goodbyeList
-                val launchIntent =
-                    context.packageManager.getLaunchIntentForPackage(phonePackageName)
-                context.startActivity(launchIntent)
-            } else {
-                val intent = Intent(Intent.ACTION_DIAL)
-                context.startActivity(intent)
-            }
-        }
-
-        imageViewContacts.setOnClickListener { v: View ->
-            val context = v.context
-            val contactsPackageName = sharedPrefs.getString("ContactsPackageName", null)
-            if (contactsPackageName != null) {
-                goodbyeList.remove(contactsPackageName) // Remove the package name from the goodbyeList
-                val launchIntent =
-                    context.packageManager.getLaunchIntentForPackage(contactsPackageName)
-                context.startActivity(launchIntent)
-            }
-        }
-
-        imageViewMessages.setOnClickListener { v: View ->
-            val context = v.context
-            val messagesPackageName = sharedPrefs.getString("MessagesPackageName", null)
-            if (messagesPackageName != null) {
-                goodbyeList.remove(messagesPackageName) // Remove the package name from the goodbyeList
-                val launchIntent =
-                    context.packageManager.getLaunchIntentForPackage(messagesPackageName)
-                context.startActivity(launchIntent)
-            }
-        }
-
-        imageViewBrowser.setOnClickListener {
-            val browser = Intent(Intent.ACTION_MAIN)
-            browser.addCategory(Intent.CATEGORY_APP_BROWSER)
-            val mainLauncherList = context?.packageManager?.queryIntentActivities(browser, 0)
-            if (mainLauncherList != null) {
-                goodbyeList.remove(mainLauncherList.first().activityInfo.packageName)
-            }
-            startActivity(browser)
-        }
-
 
         lifecycleScope.launch(Dispatchers.Default) {
             val mAppWidgetManager = AppWidgetManager.getInstance(view.context)
@@ -287,43 +135,68 @@ class HomeScreenK : Fragment(), FragmentManager.OnBackStackChangedListener {
             } catch (e: Exception) {
                 Log.d("JTError", e.toString())
             }
-
         }
-
     }
+
+    // ---- DockInteractionListener ----
+
+    override fun onDockAppClicked(item: DockItem) {
+        goodbyeList.remove(item.packageName)
+        val launchIntent = requireContext().packageManager
+            .getLaunchIntentForPackage(item.packageName)
+        if (launchIntent != null) startActivity(launchIntent)
+    }
+
+    override fun onDockDrawerClicked() {
+        widgets.animate().alpha(0f).setDuration(1000).start()
+        view?.post {
+            animateDock(500L, true)
+        }
+        loadFragment(AppsDrawer())
+    }
+
+    override fun onDockItemLongPressed(item: DockItem) {
+        AlertDialog.Builder(requireContext())
+            .setTitle(item.label)
+            .setItems(arrayOf("Remove from dock")) { _, _ ->
+                dockRepository.removeItem(item.packageName)
+                dockAdapter.updateItems(dockRepository.getDockItems())
+            }
+            .show()
+    }
+
+    // ---- Public API: called from RAdapterSystem / RAdapterDownloads long-press ----
+
+    fun addToDock(packageName: String) {
+        val added = dockRepository.addItem(packageName)
+        if (added) {
+            dockAdapter.updateItems(dockRepository.getDockItems())
+        } else {
+            val pm = requireContext().packageManager
+            val label = try {
+                pm.getApplicationLabel(pm.getApplicationInfo(packageName, 0)).toString()
+            } catch (e: PackageManager.NameNotFoundException) { packageName }
+            AlertDialog.Builder(requireContext())
+                .setMessage("$label is already in the dock, or the dock is full (max ${DockRepository.MAX_DOCK_ITEMS}).")
+                .setPositiveButton("OK", null)
+                .show()
+        }
+    }
+
+    // ---- Fragment back-stack listener ----
 
     override fun onBackStackChanged() {
-        // Get the current fragment from the back stack
         val currentFragment = parentFragmentManager.findFragmentById(R.id.container)
-
-        // Check if the AppsDrawer fragment is on the top of the stack
-        val isAppsDrawerFragmentVisible = currentFragment is AppsDrawer
-
-        // Show or hide the dock images based on the current fragment visibility
-        val animationDuration = 500L
-        animateImageViewTranslation(imageViewDrawer, animationDuration, isAppsDrawerFragmentVisible)
-        animateImageViewTranslation(imageViewPhone, animationDuration, isAppsDrawerFragmentVisible)
-        animateImageViewTranslation(
-            imageViewContacts,
-            animationDuration,
-            isAppsDrawerFragmentVisible
-        )
-        animateImageViewTranslation(
-            imageViewMessages,
-            animationDuration,
-            isAppsDrawerFragmentVisible
-        )
-        animateImageViewTranslation(
-            imageViewBrowser,
-            animationDuration,
-            isAppsDrawerFragmentVisible
-        )
-        if (isAppsDrawerFragmentVisible) {
-            gridDock.animate().alpha(0f).setDuration(500L).start()
+        val isAppsDrawerVisible = currentFragment is AppsDrawer
+        animateDock(500L, isAppsDrawerVisible)
+        if (isAppsDrawerVisible) {
+            dockRecycler.animate().alpha(0f).setDuration(500L).start()
         } else {
-            gridDock.animate().alpha(1.0f).setDuration(500L).start()
+            dockRecycler.animate().alpha(1.0f).setDuration(500L).start()
         }
     }
+
+    // ---- Fragment loading ----
 
     fun launchWithDelay(delayMillis: Long, action: () -> Unit) {
         lifecycleScope.launch {
@@ -341,12 +214,39 @@ class HomeScreenK : Fragment(), FragmentManager.OnBackStackChangedListener {
                 .beginTransaction()
                 .add(R.id.container, fragment, "apps")
                 .addToBackStack("home")
-                //.setReorderingAllowed(true)
                 .commit()
             return true
         }
         return false
     }
+
+    // ---- Dock animation (replaces per-ImageView animation) ----
+
+    private fun animateDock(duration: Long, slideDown: Boolean) {
+        val screenHeight = resources.displayMetrics.heightPixels.toFloat()
+        dockRecycler.visibility = View.VISIBLE
+        if (slideDown) {
+            dockRecycler.translationY = 0f
+            dockRecycler.animate().translationY(screenHeight).setDuration(duration).start()
+        } else {
+            dockRecycler.translationY = screenHeight
+            dockRecycler.animate().translationY(0f).setDuration(duration).start()
+        }
+    }
+
+    // ---- Theme helper ----
+
+    private fun applyDockTheme(theme: String?) {
+        val bg = when (theme) {
+            "Mochi" -> AppCompatResources.getDrawable(requireContext(), R.color.mochilight)
+            "Modern" -> AppCompatResources.getDrawable(requireContext(), R.drawable.modern_dock)
+            "System" -> AppCompatResources.getDrawable(requireContext(), R.color.abt)
+            else    -> AppCompatResources.getDrawable(requireContext(), R.drawable.quicklaunchbg)
+        }
+        dockRecycler.background = bg
+    }
+
+    // ---- Widget helper ----
 
     suspend fun createWidget(
         view: View,
@@ -355,14 +255,12 @@ class HomeScreenK : Fragment(), FragmentManager.OnBackStackChangedListener {
         mAppWidgetHost: AppWidgetHost,
         mAppWidgetManager: AppWidgetManager
     ): Boolean = withContext(Dispatchers.IO) {
-        // Get the list of installed widgets
         var newAppWidgetProviderInfo: AppWidgetProviderInfo? = null
-        val appWidgetInfos: List<AppWidgetProviderInfo>
-        appWidgetInfos = mAppWidgetManager.installedProviders
+        val appWidgetInfos = mAppWidgetManager.installedProviders
         var widgetIsFound = false
         for (j in appWidgetInfos.indices) {
-            if (appWidgetInfos[j].provider.packageName == packageName && appWidgetInfos[j].provider.className == className) {
-                // Get the full info of the required widget
+            if (appWidgetInfos[j].provider.packageName == packageName
+                && appWidgetInfos[j].provider.className == className) {
                 newAppWidgetProviderInfo = appWidgetInfos[j]
                 widgetIsFound = true
                 break
@@ -371,130 +269,79 @@ class HomeScreenK : Fragment(), FragmentManager.OnBackStackChangedListener {
         return@withContext if (!widgetIsFound) {
             false
         } else {
-            // Create Widget
             val appWidgetId = mAppWidgetHost.allocateAppWidgetId()
-            val hostView =
-                mAppWidgetHost.createView(view.context, appWidgetId, newAppWidgetProviderInfo)
+            val hostView = mAppWidgetHost.createView(view.context, appWidgetId, newAppWidgetProviderInfo)
             hostView.setAppWidget(appWidgetId, newAppWidgetProviderInfo)
-
-            // Add it to your layout
             val widgetLayout = view.findViewById<LinearLayout>(R.id.widgets)
             widgetLayout.addView(hostView)
-
-            // And bind widget IDs to make them actually work
             val allowed = mAppWidgetManager.bindAppWidgetIdIfAllowed(
-                appWidgetId,
-                newAppWidgetProviderInfo!!.provider
+                appWidgetId, newAppWidgetProviderInfo!!.provider
             )
             if (!allowed) {
                 val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_BIND)
                 intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-                intent.putExtra(
-                    AppWidgetManager.EXTRA_APPWIDGET_PROVIDER,
-                    newAppWidgetProviderInfo.provider
-                )
-                val REQUEST_BIND_WIDGET = 200906
-                startActivityForResult(intent, REQUEST_BIND_WIDGET)
+                intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_PROVIDER, newAppWidgetProviderInfo.provider)
+                startActivityForResult(intent, 200906)
             }
-            return@withContext true
+            true
         }
     }
+
+    // ---- Recents ----
 
     fun recentsList(context: Context) {
         val start = System.currentTimeMillis()
         val sharedPrefH1 = context.getSharedPreferences("Settings", Context.MODE_PRIVATE)
         if (sharedPrefH1.getBoolean("recents", false)) {
             try {
-                if (!recentsList.isEmpty()) {
-                    recentsList = mutableListOf()
-                }
-                val layoutManager = LinearLayoutManager(context)
-                recents.layoutManager = layoutManager
+                if (!recentsList.isEmpty()) recentsList = mutableListOf()
+                recents.layoutManager = LinearLayoutManager(context)
                 recents.itemAnimator = DefaultItemAnimator()
-                val usm = requireContext().getSystemService(
-                    Context.USAGE_STATS_SERVICE
-                ) as UsageStatsManager
+                val usm = requireContext().getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
                 val time = System.currentTimeMillis()
                 val aslist = usm.queryUsageStats(
-                    UsageStatsManager.INTERVAL_DAILY,
-                    time - 10000, time
+                    UsageStatsManager.INTERVAL_DAILY, time - 600000, time
                 ).toMutableList()
 
-                appStatsList = aslist.sortedBy {
-                    it.lastTimeUsed
-                }.reversed() as MutableList<UsageStats>
+                appStatsList = aslist.sortedBy { it.lastTimeUsed }.reversed() as MutableList<UsageStats>
                 appStatsList.forEach { asl ->
                     if (asl.lastTimeUsed > time - 600000) {
                         apps?.forEach { app ->
-                            if (app.packageName.equals(asl.packageName)) {
-                                if (!usm.isAppInactive(asl.packageName)) {
-                                    if (!asl.packageName.equals("com.achunt.weboslauncher")) {
-                                        if (!asl.packageName.equals("com.achunt.justtype")) {
-                                            if (!goodbyeList.contains(asl.packageName)) { // Check if the app is not in the closedAppSet
-                                                recentsList.add(app)
-                                                println(app.packageName)
-                                            }
-                                        }
-                                    }
+                            if (app.packageName == asl.packageName) {
+                                if (!usm.isAppInactive(asl.packageName)
+                                    && asl.packageName != "com.achunt.weboslauncher"
+                                    && asl.packageName != "com.achunt.justtype"
+                                    && !goodbyeList.contains(asl.packageName)) {
+                                    recentsList.add(app)
+                                    Log.d("Recents", app.packageName)
                                 }
                             }
                         }
                     }
                 }
 
-                val horizontalLayout = LinearLayoutManager(
-                    requireContext(),
-                    LinearLayoutManager.HORIZONTAL,
-                    false
+                recents.layoutManager = LinearLayoutManager(
+                    requireContext(), LinearLayoutManager.HORIZONTAL, false
                 )
-                recents.layoutManager = horizontalLayout
                 recentsAdapter = RecentsAdapter(recentsList)
                 recents.adapter = recentsAdapter
-            } catch (e: java.lang.Exception) {
+            } catch (e: Exception) {
                 e.printStackTrace()
             }
         }
-        val endFind = System.currentTimeMillis()
-        Log.d(
-            "Recents Finder",
-            "to call Recents " + (endFind - start)
-        )
+        Log.d("Recents Finder", "to call Recents " + (System.currentTimeMillis() - start))
     }
 
-
-    private fun animateImageViewTranslation(
-        imageView: ImageView,
-        animationDuration: Long,
-        down: Boolean
-    ) {
-        val screenHeight = resources.displayMetrics.heightPixels.toFloat()
-        imageView.visibility = View.VISIBLE
-        if (down) {
-            imageView.translationY = 0F
-            imageView.animate()
-                .translationY(screenHeight) // Set the final translation to the screenHeight (at the bottom)
-                .setDuration(animationDuration)
-                .start()
-        } else {
-            imageView.translationY = screenHeight
-            imageView.animate()
-                .translationY(0f)
-                .setDuration(animationDuration)
-                .start()
-        }
-    }
+    // ---- Recents click listeners ----
 
     class RecentsClickListener : View.OnClickListener {
         override fun onClick(v: View) {
-            launchItem(v)
-        }
-
-        private fun launchItem(v: View) {
             val recyclerView = v.rootView.findViewById<RecyclerView>(R.id.recents)
-            val selectedItemPosition = recyclerView.getChildPosition(v)
+            val pos = recyclerView.getChildAdapterPosition(v)
+            if (pos == RecyclerView.NO_POSITION) return
             v.context.startActivity(
                 v.context.packageManager.getLaunchIntentForPackage(
-                    recentsList[selectedItemPosition].packageName as String
+                    recentsList[pos].packageName as String
                 )
             )
         }
@@ -502,46 +349,28 @@ class HomeScreenK : Fragment(), FragmentManager.OnBackStackChangedListener {
 
     class RecentsLongClickListener : View.OnLongClickListener {
         override fun onLongClick(v: View): Boolean {
-            removeItem(v)
+            val recyclerView = v.rootView.findViewById<RecyclerView>(R.id.recents)
+            val pos = recyclerView.getChildAdapterPosition(v)
+            if (pos == RecyclerView.NO_POSITION) return true
+            v.animate().translationY(-2000f).setDuration(500).start()
+            val packageName = recentsList[pos].packageName
+            val manager = v.rootView.context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+            manager.killBackgroundProcesses(packageName as String?)
+            goodbyeList.add(packageName as String)
+            Handler(Looper.getMainLooper()).postDelayed({
+                recentsList.removeAt(pos)
+                recentsAdapter.notifyItemRemoved(pos)
+            }, 500)
             return true
         }
-
-        private fun removeItem(v: View) {
-            v.animate()
-                .translationY(-2000f)
-                .setDuration(500)
-                .start()
-            val recyclerView = v.rootView.findViewById<RecyclerView>(R.id.recents)
-            val selectedItemPosition = recyclerView.getChildAdapterPosition(v)
-            val packageName = recentsList[selectedItemPosition].packageName
-            val manager =
-                v.rootView.context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-            manager.killBackgroundProcesses(packageName as String?)
-            goodbyeList.add(packageName as String) // Add the closed app's package name to the set
-            Handler().postDelayed({
-                recentsList.removeAt(selectedItemPosition)
-                recentsAdapter.notifyItemRemoved(selectedItemPosition)
-            }, 500)
-        }
-
     }
 
-
     companion object {
-        @Volatile
-        lateinit var adapter: RAdapter
-
-        @Volatile
-        lateinit var adapterSystem: RecyclerView.Adapter<*>
-
-        @Volatile
-        lateinit var adapterDownloads: RecyclerView.Adapter<*>
-
-        @Volatile
-        lateinit var adapterSettings: RecyclerView.Adapter<*>
-
-        @Volatile
-        lateinit var adapterWork: RecyclerView.Adapter<*>
+        @Volatile lateinit var adapter: RAdapter
+        @Volatile lateinit var adapterSystem: RecyclerView.Adapter<*>
+        @Volatile lateinit var adapterDownloads: RecyclerView.Adapter<*>
+        @Volatile lateinit var adapterSettings: RecyclerView.Adapter<*>
+        @Volatile lateinit var adapterWork: RecyclerView.Adapter<*>
         const val APPWIDGET_HOST_ID = 200906
         lateinit var appStatsList: MutableList<UsageStats>
         lateinit var recentsAdapter: RecentsAdapter

--- a/app/src/main/res/layout/homescreen.xml
+++ b/app/src/main/res/layout/homescreen.xml
@@ -7,7 +7,6 @@
     app:defaultNavHost="true"
     app:navGraph="@navigation/nav_graph">
 
-
     <LinearLayout
         android:id="@+id/widgets"
         android:layout_width="match_parent"
@@ -15,10 +14,7 @@
         android:orientation="vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-    </LinearLayout>
-
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recents"
@@ -27,102 +23,23 @@
         android:orientation="horizontal"
         app:layout_constraintBottom_toTopOf="@+id/dock"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/widgets">
+        app:layout_constraintTop_toBottomOf="@+id/widgets" />
 
-    </androidx.recyclerview.widget.RecyclerView>
-
-
-    <GridLayout
+    <!--
+        Dock: replaced the hardcoded GridLayout + 5 fixed ImageViews with a
+        RecyclerView. Items are managed by DockAdapter / DockRepository.
+        The background and height are preserved from the original GridLayout.
+    -->
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/dock"
         android:layout_width="match_parent"
         android:layout_height="64dp"
         android:animateLayoutChanges="true"
         android:background="@drawable/quicklaunchbg"
-        android:columnCount="5"
         android:gravity="center"
+        android:orientation="horizontal"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-
-        <ImageView
-            android:id="@+id/phone"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_columnWeight="1"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginLeft="2dp"
-            android:layout_marginRight="2dp"
-            android:adjustViewBounds="true"
-            android:background="@drawable/dockshadow"
-            android:cropToPadding="true"
-            android:scaleType="centerInside"
-            android:visibility="invisible"
-            tools:ignore="MissingConstraints" />
-
-        <ImageView
-            android:id="@+id/cnt"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_columnWeight="1"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginLeft="2dp"
-            android:layout_marginRight="2dp"
-            android:adjustViewBounds="true"
-            android:background="@drawable/dockshadow"
-            android:cropToPadding="true"
-            android:scaleType="centerInside"
-            android:visibility="invisible"
-            tools:ignore="MissingConstraints" />
-
-        <ImageView
-            android:id="@+id/msg"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_columnWeight="1"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginLeft="2dp"
-            android:layout_marginRight="2dp"
-            android:adjustViewBounds="true"
-            android:background="@drawable/dockshadow"
-            android:cropToPadding="true"
-            android:scaleType="centerInside"
-            android:visibility="invisible"
-            tools:ignore="MissingConstraints" />
-
-        <ImageView
-            android:id="@+id/brs"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_columnWeight="1"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginLeft="2dp"
-            android:layout_marginRight="2dp"
-            android:adjustViewBounds="true"
-            android:background="@drawable/dockshadow"
-            android:cropToPadding="true"
-            android:scaleType="centerInside"
-            android:visibility="invisible"
-            tools:ignore="MissingConstraints" />
-
-        <ImageView
-            android:id="@+id/icon_drawer"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_columnWeight="1"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginLeft="2dp"
-            android:layout_marginRight="2dp"
-            android:adjustViewBounds="true"
-            android:background="@drawable/dockshadow"
-            android:cropToPadding="true"
-            android:scaleType="centerInside"
-            android:src="@drawable/applauncher"
-            android:visibility="invisible"
-            tools:ignore="MissingConstraints" />
-        <!--android:layout_marginLeft="6dp"
-            android:layout_marginRight="6dp"-->
-
-
-    </GridLayout>
-
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:ignore="MissingConstraints" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_dock.xml
+++ b/app/src/main/res/layout/item_dock.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="64dp"
+    android:layout_marginStart="2dp"
+    android:layout_marginEnd="2dp">
+
+    <ImageView
+        android:id="@+id/dock_item_icon"
+        android:layout_width="56dp"
+        android:layout_height="56dp"
+        android:layout_gravity="center"
+        android:adjustViewBounds="true"
+        android:cropToPadding="true"
+        android:scaleType="centerInside"
+        android:contentDescription="@null" />
+
+</FrameLayout>


### PR DESCRIPTION
## Dynamic Dock

Replaces the hardcoded 5-slot `GridLayout` with a fully data-driven `RecyclerView` dock. Users can now add and remove apps freely, and the dock persists across restarts.

---

### New files

**`DockItem.kt`**
- Simple data class: `packageName`, `label`, `isDrawerButton`
- No icon stored — loaded from `PackageManager` at bind time so it's always fresh

**`DockRepository.kt`**
- Single source of truth for dock state
- Persists an ordered JSON array of package names in `SharedPreferences` (`DockPrefs`)
- The drawer button is a runtime sentinel (`__drawer__`) — never written to disk
- `seedFromLegacy()` reads from `SpecialApps` SharedPreferences (existing phone/contacts/messages/browser config) on first launch so no user data is lost
- Falls back to intent-resolution (ACTION_DIAL, content://contacts, smsto:, http://) for any slot not found in legacy prefs
- Auto-cleans uninstalled apps on read
- Max 6 customizable slots + drawer button

**`DockAdapter.kt`**
- Horizontal `RecyclerView.Adapter` driving `item_dock.xml`
- Tap → launch app / open drawer
- Long-press → delegates to `HomeScreenK.onDockItemLongPressed` (shows remove dialog)
- `updateItems()` for full list refresh after any mutation

**`item_dock.xml`**
- `FrameLayout` wrapping a 56dp × 64dp `ImageView` with `dockshadow` background
- Matches the original per-slot visual exactly

---

### Modified files

**`homescreen.xml`**
- `GridLayout` + 5 hardcoded `ImageView`s removed
- Replaced with a single `RecyclerView` (`@id/dock`) — same height, background, and constraint anchors preserved

**`HomeScreenK.kt`**
- Implements `DockAdapter.DockInteractionListener`
- `onViewCreated`: seeds repo on first launch, wires `LinearLayoutManager` (horizontal) + `DockAdapter`
- `onDockAppClicked`: launches the app (also removes from `goodbyeList` so it re-appears in recents)
- `onDockDrawerClicked`: replaces the old `icon_drawer` click handler — fades widgets, slides dock down, loads `AppsDrawer`
- `onDockItemLongPressed`: shows an `AlertDialog` with a "Remove from dock" option
- `addToDock(packageName)`: public method for `RAdapterSystem`/`RAdapterDownloads` to call from a long-press "Add to Dock" menu item
- `animateDock()`: consolidated helper — translates the whole `RecyclerView` up/down instead of animating 5 individual `ImageView`s
- `onBackStackChanged`: alpha-animates `dockRecycler` in/out when apps drawer opens/closes
- All legacy `phone`/`cnt`/`msg`/`brs`/`icon_drawer` view references removed